### PR TITLE
Expand test coverage across nodes, lowfat, and TSV

### DIFF
--- a/test/test_lowfat.py
+++ b/test/test_lowfat.py
@@ -2,6 +2,7 @@ import pytest
 import os
 import codecs
 import re
+import unicodedata
 from lxml import etree
 from test import __lowfat_files__, run_xpath_for_file
 
@@ -25,6 +26,20 @@ def test_file_is_valid_utf8(lowfat_file):
 @pytest.mark.parametrize("lowfat_file", __lowfat_files__)
 def test_file_is_valid_xml(lowfat_file):
     assert etree.parse(lowfat_file)
+
+
+@pytest.mark.parametrize("lowfat_file", __lowfat_files__)
+def test_file_is_nfc(lowfat_file):
+    """All text in the file must be Unicode NFC."""
+    text = open(lowfat_file, encoding="utf-8").read()
+    assert unicodedata.normalize("NFC", text) == text, "File contains non-NFC text"
+
+
+@pytest.mark.parametrize("lowfat_file", __lowfat_files__)
+def test_no_cgj_anywhere(lowfat_file):
+    """CGJ (U+034F) must not appear anywhere in the file."""
+    text = open(lowfat_file, encoding="utf-8").read()
+    assert "\u034f" not in text, "File contains CGJ (U+034F)"
 
 
 @pytest.mark.parametrize("lowfat_file", __lowfat_files__)
@@ -56,6 +71,20 @@ def test_required_attrs_exist_on_w_elements(lowfat_file):
                     if IS_SUBSUMED_DEFINITE_ARTICLE.match(macula_id):
                         continue
                 raise
+
+
+@pytest.mark.parametrize("lowfat_file", __lowfat_files__)
+def test_w_lemma_not_empty(lowfat_file):
+    """Every <w> element must have a non-empty @lemma."""
+    bad = run_xpath_for_file("//w[not(@lemma) or @lemma='']", lowfat_file)
+    assert not bad, f"Found {len(bad)} <w> elements with missing/empty @lemma"
+
+
+@pytest.mark.parametrize("lowfat_file", __lowfat_files__)
+def test_w_after_not_missing(lowfat_file):
+    """Every <w> element must have an @after attribute."""
+    bad = run_xpath_for_file("//w[not(@after)]", lowfat_file)
+    assert not bad, f"Found {len(bad)} <w> elements missing @after"
 
 
 def test_number_of_lowfat_words():

--- a/test/test_nodes.py
+++ b/test/test_nodes.py
@@ -2,8 +2,15 @@ import pytest
 import os
 import codecs
 import re
+import unicodedata
+import collections
 from lxml import etree
 from test import __nodes_files__, run_xpath_for_file
+
+
+XML_ID_PATTERN = re.compile(r"^o\d+ה?$")  # optional ה suffix for subsumed definite articles
+
+VALID_AFTER_VALUES = {" ", "־", "׃", "׀", "׃פ", "׃ס", "ס", "פ", ""}
 
 
 @pytest.mark.parametrize("node_file", __nodes_files__)
@@ -21,6 +28,20 @@ def test_file_is_valid_utf8(node_file):
 @pytest.mark.parametrize("node_file", __nodes_files__)
 def test_file_is_valid_xml(node_file):
     assert etree.parse(node_file)
+
+
+@pytest.mark.parametrize("node_file", __nodes_files__)
+def test_file_is_nfc(node_file):
+    """All text in the file must be Unicode NFC."""
+    text = open(node_file, encoding="utf-8").read()
+    assert unicodedata.normalize("NFC", text) == text, "File contains non-NFC text"
+
+
+@pytest.mark.parametrize("node_file", __nodes_files__)
+def test_no_cgj_anywhere(node_file):
+    """CGJ (U+034F) must not appear anywhere in the file."""
+    text = open(node_file, encoding="utf-8").read()
+    assert "\u034f" not in text, "File contains CGJ (U+034F)"
 
 
 @pytest.mark.parametrize("node_file", __nodes_files__)
@@ -48,9 +69,73 @@ def test_required_attrs_exist_on_w_elements(node_file):
 
 
 @pytest.mark.parametrize("node_file", __nodes_files__)
+def test_m_xml_id_format(node_file):
+    """Every <m> element must have an xml:id of the form o<digits> (with optional ה suffix)."""
+    XML_ID = "{http://www.w3.org/XML/1998/namespace}id"
+    for m in etree.parse(node_file).xpath("//m"):
+        xml_id = m.get(XML_ID, "")
+        assert XML_ID_PATTERN.match(xml_id), f"Bad xml:id on <m>: {repr(xml_id)}"
+
+
+@pytest.mark.parametrize("node_file", __nodes_files__)
+def test_m_lemma_not_empty(node_file):
+    """Every <m> element must have a non-empty @lemma."""
+    bad = run_xpath_for_file("//m[not(@lemma) or @lemma='']", node_file)
+    assert not bad, f"Found {len(bad)} <m> elements with missing/empty @lemma"
+
+
+@pytest.mark.parametrize("node_file", __nodes_files__)
+def test_m_morph_not_empty(node_file):
+    """Every <m> element must have a non-empty @morph."""
+    bad = run_xpath_for_file("//m[not(@morph) or @morph='']", node_file)
+    assert not bad, f"Found {len(bad)} <m> elements with missing/empty @morph"
+
+
+@pytest.mark.parametrize("node_file", __nodes_files__)
+def test_m_after_valid_values(node_file):
+    """Every @after on <m> elements must be one of the known separator values."""
+    for m in etree.parse(node_file).xpath("//m[@after]"):
+        after = m.get("after")
+        assert after in VALID_AFTER_VALUES, (
+            f"Unexpected @after value {repr(after)} on "
+            f"xml:id={m.get('{http://www.w3.org/XML/1998/namespace}id')}"
+        )
+
+
+@pytest.mark.parametrize("node_file", __nodes_files__)
 def test_last_m_in_tree_after_not_missing_or_empty(node_file):
     xpath = "//Tree/descendant::m[last()][not(@after) or @after='']"
     assert not run_xpath_for_file(xpath, node_file)
+
+
+@pytest.mark.parametrize("node_file", __nodes_files__)
+def test_non_final_word_last_m_has_after(node_file):
+    """Last morpheme of each non-final orthographic word must have non-empty @after."""
+    tree = etree.parse(node_file)
+    violations = []
+    for sentence in tree.xpath("//Sentence"):
+        word_groups = collections.OrderedDict()
+        for m in sentence.iter("m"):
+            w = m.get("word", "")
+            if w not in word_groups:
+                word_groups[w] = []
+            word_groups[w].append(m)
+
+        word_ids = list(word_groups.keys())
+        for i, word_id in enumerate(word_ids):
+            if i == len(word_ids) - 1:
+                continue
+            last_m = word_groups[word_id][-1]
+            after = last_m.get("after", None)
+            if after is None or after == "":
+                xml_id = last_m.get(
+                    "{http://www.w3.org/XML/1998/namespace}id", "?"
+                )
+                violations.append(f"word={word_id} xml:id={xml_id}")
+
+    assert not violations, (
+        f"Non-final words with empty/missing @after: {violations[:5]}"
+    )
 
 
 def test_number_of_nodes_words():

--- a/test/test_tsv.py
+++ b/test/test_tsv.py
@@ -1,7 +1,14 @@
 import os
 import codecs
+import re
+import unicodedata
 import pytest
 from test import __macula_hebrew_tsv_rows__, __tsv_files__
+
+
+REF_PATTERN = re.compile(r"^[A-Z0-9]{3} [0-9]+:[0-9]+![0-9]+$")
+XML_ID_PATTERN = re.compile(r"^o\d+ה?$")  # optional ה suffix for subsumed definite articles
+VALID_AFTER_VALUES = {" ", "־", "׃", "׀", "׃פ", "׃ס", "ס", "פ", ""}
 
 
 @pytest.mark.parametrize("tsv_file", __tsv_files__)
@@ -16,11 +23,50 @@ def test_file_is_valid_utf8(tsv_file):
     assert lines != ""
 
 
+def test_tsv_no_cgj():
+    """CGJ (U+034F) must not appear anywhere in the TSV."""
+    with open("../WLC/tsv/macula-hebrew.tsv", encoding="utf-8") as f:
+        content = f.read()
+    assert "\u034f" not in content, "TSV contains CGJ (U+034F)"
+
+
+def test_tsv_is_nfc():
+    """All text in the TSV must be Unicode NFC."""
+    with open("../WLC/tsv/macula-hebrew.tsv", encoding="utf-8") as f:
+        content = f.read()
+    assert unicodedata.normalize("NFC", content) == content, "TSV contains non-NFC text"
+
+
 def test_tsv_row_has_id():
     for tsv_row in __macula_hebrew_tsv_rows__:
         id = tsv_row["xml:id"]
         assert id != ""
         assert id[0] == "o"
+
+
+def test_tsv_xml_id_format():
+    for tsv_row in __macula_hebrew_tsv_rows__:
+        assert XML_ID_PATTERN.match(tsv_row["xml:id"]), (
+            f"Bad xml:id: {repr(tsv_row['xml:id'])}"
+        )
+
+
+def test_tsv_ref_format():
+    for tsv_row in __macula_hebrew_tsv_rows__:
+        assert REF_PATTERN.match(tsv_row["ref"]), (
+            f"Bad ref: {repr(tsv_row['ref'])}"
+        )
+
+
+def test_tsv_after_valid_values():
+    for tsv_row in __macula_hebrew_tsv_rows__:
+        after = tsv_row["after"]
+        assert after in VALID_AFTER_VALUES, f"Unexpected after value: {repr(after)}"
+
+
+def test_tsv_lemma_not_empty():
+    for tsv_row in __macula_hebrew_tsv_rows__:
+        assert tsv_row["lemma"], f"Empty lemma for {tsv_row['xml:id']}"
 
 
 def test_tsv_row_count():


### PR DESCRIPTION
## Summary

Adds tests that catch the bugs fixed by PRs #136, #137, and #140, and enforce data quality constraints going forward.

## New tests

**test_nodes.py**
- `test_file_is_nfc` — all text must be Unicode NFC
- `test_no_cgj_anywhere` — no CGJ (U+034F) anywhere in file
- `test_m_xml_id_format` — `xml:id` must be `o<digits>` (with optional `ה` suffix for subsumed definite articles)
- `test_m_lemma_not_empty` — every `<m>` has non-empty `@lemma`
- `test_m_morph_not_empty` — every `<m>` has non-empty `@morph`
- `test_m_after_valid_values` — `@after` must be from the known valid set
- `test_non_final_word_last_m_has_after` — last morpheme of each non-final orthographic word has non-empty `@after`

**test_lowfat.py**
- `test_file_is_nfc` — all text must be Unicode NFC
- `test_no_cgj_anywhere` — no CGJ anywhere in file
- `test_w_lemma_not_empty` — every `<w>` has non-empty `@lemma`
- `test_w_after_not_missing` — every `<w>` has an `@after` attribute

**test_tsv.py**
- `test_tsv_is_nfc` — all text must be Unicode NFC
- `test_tsv_no_cgj` — no CGJ in the TSV
- `test_tsv_xml_id_format` — `xml:id` matches expected format
- `test_tsv_ref_format` — `ref` matches USFM pattern
- `test_tsv_after_valid_values` — `after` column from known valid set
- `test_tsv_lemma_not_empty` — every row has non-empty `lemma`

## Expected failures until other PRs merge

| Test | Passes after |
|------|-------------|
| `test_file_is_nfc`, `test_no_cgj_anywhere` (nodes) | PR #136 merges |
| `test_file_is_nfc`, `test_no_cgj_anywhere`, `test_w_after_not_missing` (lowfat) | PRs #136 + #137 merge + lowfat regenerated |
| `test_tsv_is_nfc`, `test_tsv_no_cgj` | PRs #136 + #137 merge + TSV regenerated |
| `test_non_final_word_last_m_has_after` (nodes) | PR #137 merges |

🤖 Generated with [Claude Code](https://claude.com/claude-code)